### PR TITLE
Update AbstractDecoder.php

### DIFF
--- a/src/Intervention/Image/AbstractDecoder.php
+++ b/src/Intervention/Image/AbstractDecoder.php
@@ -208,6 +208,7 @@ abstract class AbstractDecoder
      */
     public function isUrl()
     {
+        this->data = filter_var(this->data, FILTER_SANITIZE_URL);
         return (bool) filter_var($this->data, FILTER_VALIDATE_URL);
     }
 


### PR DESCRIPTION
This will fix some errors with special characters like 'á'.
Of course, it will just validate if it's a URL, then it can fail for any other reason, but not because this considers that this is not a URL, when it is.